### PR TITLE
优化IO流操作可能的GC问题以及部分代码格式、注释的修改

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/img/gif/AnimatedGifEncoder.java
+++ b/hutool-core/src/main/java/cn/hutool/core/img/gif/AnimatedGifEncoder.java
@@ -5,9 +5,11 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
+
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /**
  * 动态GIF动画生成器，可生成一个或多个帧的GIF。
@@ -296,7 +298,7 @@ public class AnimatedGifEncoder {
 	public boolean start(String file) {
 		boolean ok;
 		try {
-			out = new BufferedOutputStream(new FileOutputStream(file));
+			out = new BufferedOutputStream(Files.newOutputStream(Paths.get(file)));
 			ok = start(out);
 			closeStream = true;
 		} catch (IOException e) {

--- a/hutool-core/src/main/java/cn/hutool/core/img/gif/GifDecoder.java
+++ b/hutool-core/src/main/java/cn/hutool/core/img/gif/GifDecoder.java
@@ -10,10 +10,11 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferInt;
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 
 /**
@@ -339,7 +340,7 @@ public class GifDecoder {
 				URL url = new URL(name);
 				in = new BufferedInputStream(url.openStream());
 			} else {
-				in = new BufferedInputStream(new FileInputStream(name));
+				in = new BufferedInputStream(Files.newInputStream(Paths.get(name)));
 			}
 			status = read(in);
 		} catch (IOException e) {

--- a/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.LineNumberReader;
@@ -137,7 +136,7 @@ public class FileUtil extends PathUtil {
 	 * @return 是否为空，当提供非目录时，返回false
 	 */
 	public static boolean isEmpty(File file) {
-		if (null == file || false == file.exists()) {
+		if (null == file || !file.exists()) {
 			return true;
 		}
 
@@ -158,7 +157,7 @@ public class FileUtil extends PathUtil {
 	 * @return 是否为空，当提供非目录时，返回false
 	 */
 	public static boolean isNotEmpty(File file) {
-		return false == isEmpty(file);
+		return !isEmpty(file);
 	}
 
 	/**
@@ -493,7 +492,7 @@ public class FileUtil extends PathUtil {
 	 */
 	public static boolean exist(String directory, String regexp) {
 		final File file = new File(directory);
-		if (false == file.exists()) {
+		if (!file.exists()) {
 			return false;
 		}
 
@@ -518,7 +517,7 @@ public class FileUtil extends PathUtil {
 	 * @return 最后修改时间
 	 */
 	public static Date lastModifiedTime(File file) {
-		if (false == exist(file)) {
+		if (!exist(file)) {
 			return null;
 		}
 
@@ -559,7 +558,7 @@ public class FileUtil extends PathUtil {
 	 * @since 5.7.21
 	 */
 	public static long size(File file, boolean includeDirSize) {
-		if (null == file || false == file.exists() || isSymlink(file)) {
+		if (null == file || !file.exists() || isSymlink(file)) {
 			return 0;
 		}
 
@@ -587,7 +586,7 @@ public class FileUtil extends PathUtil {
 	 * @since 5.7.22
 	 */
 	public static int getTotalLines(File file) {
-		if (false == isFile(file)) {
+		if (!isFile(file)) {
 			throw new IORuntimeException("Input must be a File");
 		}
 		try (final LineNumberReader lineNumberReader = new LineNumberReader(new java.io.FileReader(file))) {
@@ -611,7 +610,7 @@ public class FileUtil extends PathUtil {
 	 * @return 是否晚于给定时间
 	 */
 	public static boolean newerThan(File file, File reference) {
-		if (null == reference || false == reference.exists()) {
+		if (null == reference || !reference.exists()) {
 			return true;// 文件一定比一个不存在的文件新
 		}
 		return newerThan(file, reference.lastModified());
@@ -625,7 +624,7 @@ public class FileUtil extends PathUtil {
 	 * @return 是否晚于给定时间
 	 */
 	public static boolean newerThan(File file, long timeMillis) {
-		if (null == file || false == file.exists()) {
+		if (null == file || !file.exists()) {
 			return false;// 不存在的文件一定比任何时间旧
 		}
 		return file.lastModified() > timeMillis;
@@ -658,7 +657,7 @@ public class FileUtil extends PathUtil {
 		if (null == file) {
 			return null;
 		}
-		if (false == file.exists()) {
+		if (!file.exists()) {
 			mkParentDirs(file);
 			try {
 				//noinspection ResultOfMethodCallIgnored
@@ -751,7 +750,7 @@ public class FileUtil extends PathUtil {
 	 * @see Files#delete(Path)
 	 */
 	public static boolean del(File file) throws IORuntimeException {
-		if (file == null || false == file.exists()) {
+		if (file == null || !file.exists()) {
 			// 如果文件不存在或已被删除，此处返回true表示删除成功
 			return true;
 		}
@@ -759,7 +758,7 @@ public class FileUtil extends PathUtil {
 		if (file.isDirectory()) {
 			// 清空目录下所有文件和目录
 			boolean isOk = clean(file);
-			if (false == isOk) {
+			if (!isOk) {
 				return false;
 			}
 		}
@@ -803,14 +802,14 @@ public class FileUtil extends PathUtil {
 	 * @since 3.0.6
 	 */
 	public static boolean clean(File directory) throws IORuntimeException {
-		if (directory == null || directory.exists() == false || false == directory.isDirectory()) {
+		if ((directory == null) || !directory.exists() || !directory.isDirectory()) {
 			return true;
 		}
 
 		final File[] files = directory.listFiles();
 		if (null != files) {
 			for (File childFile : files) {
-				if (false == del(childFile)) {
+				if (!del(childFile)) {
 					// 删除一个出错则本次删除任务失败
 					return false;
 				}
@@ -830,7 +829,7 @@ public class FileUtil extends PathUtil {
 	 * @since 4.5.5
 	 */
 	public static boolean cleanEmpty(File directory) throws IORuntimeException {
-		if (directory == null || false == directory.exists() || false == directory.isDirectory()) {
+		if (directory == null || !directory.exists() || !directory.isDirectory()) {
 			return true;
 		}
 
@@ -872,7 +871,7 @@ public class FileUtil extends PathUtil {
 		if (dir == null) {
 			return null;
 		}
-		if (false == dir.exists()) {
+		if (!dir.exists()) {
 			mkdirsSafely(dir, 5, 1);
 		}
 		return dir;
@@ -1048,7 +1047,7 @@ public class FileUtil extends PathUtil {
 	public static File copyFile(File src, File dest, StandardCopyOption... options) throws IORuntimeException {
 		// check
 		Assert.notNull(src, "Source File is null !");
-		if (false == src.exists()) {
+		if (!src.exists()) {
 			throw new IORuntimeException("File not exist: " + src);
 		}
 		Assert.notNull(dest, "Destination File or directiory is null !");
@@ -1376,10 +1375,10 @@ public class FileUtil extends PathUtil {
 	public static boolean equals(File file1, File file2) throws IORuntimeException {
 		Assert.notNull(file1);
 		Assert.notNull(file2);
-		if (false == file1.exists() || false == file2.exists()) {
+		if (!file1.exists() || !file2.exists()) {
 			// 两个文件都不存在判断其路径是否相同， 对于一个存在一个不存在的情况，一定不相同
-			return false == file1.exists()//
-					&& false == file2.exists()//
+			return !file1.exists()//
+					&& !file2.exists()//
 					&& pathEquals(file1, file2);
 		}
 		return equals(file1.toPath(), file2.toPath());
@@ -1402,7 +1401,7 @@ public class FileUtil extends PathUtil {
 			return false;
 		}
 
-		if (false == file1Exists) {
+		if (!file1Exists) {
 			// 两个文件都不存在，返回true
 			return true;
 		}
@@ -1562,7 +1561,7 @@ public class FileUtil extends PathUtil {
 	 * @return 是否被改动
 	 */
 	public static boolean isModified(File file, long lastModifyTime) {
-		if (null == file || false == file.exists()) {
+		if (null == file || !file.exists()) {
 			return true;
 		}
 		return file.lastModified() != lastModifyTime;
@@ -1634,7 +1633,7 @@ public class FileUtil extends PathUtil {
 				// 去除类似于/C:这类路径开头的斜杠
 				prefix = prefix.substring(1);
 			}
-			if (false == prefix.contains(StrUtil.SLASH)) {
+			if (!prefix.contains(StrUtil.SLASH)) {
 				pathToUse = pathToUse.substring(prefixIndex + 1);
 			} else {
 				// 如果前缀中包含/,说明非Windows风格path
@@ -1654,7 +1653,7 @@ public class FileUtil extends PathUtil {
 		for (int i = pathList.size() - 1; i >= 0; i--) {
 			element = pathList.get(i);
 			// 只处理非.的目录，即只处理非当前目录
-			if (false == StrUtil.DOT.equals(element)) {
+			if (!StrUtil.DOT.equals(element)) {
 				if (StrUtil.DOUBLE_DOT.equals(element)) {
 					tops++;
 				} else {
@@ -1917,8 +1916,8 @@ public class FileUtil extends PathUtil {
 	 */
 	public static BOMInputStream getBOMInputStream(File file) throws IORuntimeException {
 		try {
-			return new BOMInputStream(new FileInputStream(file));
-		} catch (IOException e) {
+			return new BOMInputStream(Files.newInputStream(file.toPath()));
+		} catch (final IOException e) {
 			throw new IORuntimeException(e);
 		}
 	}
@@ -2561,8 +2560,8 @@ public class FileUtil extends PathUtil {
 	public static BufferedOutputStream getOutputStream(File file) throws IORuntimeException {
 		final OutputStream out;
 		try {
-			out = new FileOutputStream(touch(file));
-		} catch (IOException e) {
+			out = Files.newOutputStream(touch(file).toPath());
+		} catch (final IOException e) {
 			throw new IORuntimeException(e);
 		}
 		return IoUtil.toBuffered(out);
@@ -3437,7 +3436,7 @@ public class FileUtil extends PathUtil {
 				parentCanonicalPath = parentFile.getAbsolutePath();
 				canonicalPath = file.getAbsolutePath();
 			}
-			if (false == canonicalPath.startsWith(parentCanonicalPath)) {
+			if (!canonicalPath.startsWith(parentCanonicalPath)) {
 				throw new IllegalArgumentException("New file is outside of the parent dir: " + file.getName());
 			}
 		}
@@ -3574,7 +3573,7 @@ public class FileUtil extends PathUtil {
 	private static File buildFile(File outFile, String fileName) {
 		// 替换Windows路径分隔符为Linux路径分隔符，便于统一处理
 		fileName = fileName.replace('\\', '/');
-		if (false == isWindows()
+		if (!isWindows()
 				// 检查文件名中是否包含"/"，不考虑以"/"结尾的情况
 				&& fileName.lastIndexOf(CharUtil.SLASH, fileName.length() - 2) > 0) {
 			// 在Linux下多层目录创建存在问题，/会被当成文件名的一部分，此处做处理

--- a/hutool-core/src/main/java/cn/hutool/core/io/IoUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/IoUtil.java
@@ -914,7 +914,7 @@ public class IoUtil extends NioUtil {
 		if (null == in) {
 			return null;
 		}
-		if (false == in.markSupported()) {
+		if (!in.markSupported()) {
 			return new BufferedInputStream(in);
 		}
 		return in;
@@ -1143,10 +1143,10 @@ public class IoUtil extends NioUtil {
 	 * @since 4.0.6
 	 */
 	public static boolean contentEquals(InputStream input1, InputStream input2) throws IORuntimeException {
-		if (false == (input1 instanceof BufferedInputStream)) {
+		if (!(input1 instanceof BufferedInputStream)) {
 			input1 = new BufferedInputStream(input1);
 		}
-		if (false == (input2 instanceof BufferedInputStream)) {
+		if (!(input2 instanceof BufferedInputStream)) {
 			input2 = new BufferedInputStream(input2);
 		}
 

--- a/hutool-core/src/main/java/cn/hutool/core/io/file/FileWriter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/FileWriter.java
@@ -13,9 +13,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -335,10 +337,10 @@ public class FileWriter extends FileWrapper {
 	 * @throws IORuntimeException IO异常
 	 * @since 5.5.2
 	 */
-	public File writeFromStream(InputStream in, boolean isCloseIn) throws IORuntimeException {
-		FileOutputStream out = null;
+	public File writeFromStream(final InputStream in, final boolean isCloseIn) throws IORuntimeException {
+		OutputStream out = null;
 		try {
-			out = new FileOutputStream(FileUtil.touch(file));
+			out = Files.newOutputStream(FileUtil.touch(file).toPath());
 			IoUtil.copy(in, out);
 		} catch (IOException e) {
 			throw new IORuntimeException(e);
@@ -359,8 +361,8 @@ public class FileWriter extends FileWrapper {
 	 */
 	public BufferedOutputStream getOutputStream() throws IORuntimeException {
 		try {
-			return new BufferedOutputStream(new FileOutputStream(FileUtil.touch(file)));
-		} catch (IOException e) {
+			return new BufferedOutputStream(Files.newOutputStream(FileUtil.touch(file).toPath()));
+		} catch (final IOException e) {
 			throw new IORuntimeException(e);
 		}
 	}
@@ -398,7 +400,7 @@ public class FileWriter extends FileWrapper {
 	 */
 	private void checkFile() throws IORuntimeException {
 		Assert.notNull(file, "File to write content is null !");
-		if (this.file.exists() && false == file.isFile()) {
+		if (this.file.exists() && !file.isFile()) {
 			throw new IORuntimeException("File [{}] is not a file !", this.file.getAbsoluteFile());
 		}
 	}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. 修改IoUtil中write方法的注释
2. 根据[JDK-8080225](https://bugs.openjdk.org/browse/JDK-8080225)修改了部分新建文件输入流和文件输出流的创建方式，部分FileUtil中的部分由于方法返回类型不为InputStream，所以没有修改
3. 简化了FileUtil/IoUtil中部分if判读条件语法格式（IDEA有警告）

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过